### PR TITLE
Disable Flask debug mode on app

### DIFF
--- a/flask/application.py
+++ b/flask/application.py
@@ -103,6 +103,6 @@ def humid():
 
 
 if __name__ == '__main__':
-    application.run(debug=True)
+    application.run(debug=False)
 
 ####


### PR DESCRIPTION
The code change is for turning off debug mode to prevent inadvertent deployment of insecure resources.

*Issue #, if available:*

*Description of changes:*
The debug mode flag is set to false for the application.py/application.run(). If this were to be deployed publicly the flask back end can be used to run arbitrary code. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
